### PR TITLE
fixed handling of code 0x0003 for relays >8 ch

### DIFF
--- a/lib/commands.js
+++ b/lib/commands.js
@@ -84,9 +84,9 @@ module.exports = {
 
       for (var i = 3, length = buffer.length; i < length; i++) {
         var byte = buffer.readUInt8(i);
-        var offset = i - 3;
+        var offset = (i - 3) * 8;
 
-        for (var n = 0; n < 8 && (offset * 8) + n < channels.length; n++)
+        for (var n = 0; n < 8 && offset + n < channels.length; n++)
           channels[offset + n] = {
             number: offset + n + 1,
             status: !!(byte & (1 << n))


### PR DESCRIPTION
Fixed offset definition so (offset + n) in lines 90 and 91 is now calculated properly.

This should address the recent issue that I opened (https://github.com/mrgadget/node-red-contrib-hdlbus/issues/3). 